### PR TITLE
Clean and add nb_config_manager, nbbrowserpdf dependency

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -13,6 +13,6 @@ engine:
   - python=3.5
 
 script:
-  - conda build conda.recipe -c javascript -c mutirri -c cpcloud
+  - conda build conda.recipe -c javascript -c mutirri -c cpcloud -c anaconda-nb-extensions
 
 build_targets: conda

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - notebook
     - python
     - nb_config_manager
-    - nbbrowserpdf
 
 test:
   files:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - funcsigs
     - notebook
     - python
+    - nb_config_manager
+    - nbbrowserpdf
 
 test:
   files:

--- a/nbpresent/install.py
+++ b/nbpresent/install.py
@@ -40,12 +40,13 @@ def install(enable=False, **kwargs):
     install_nbextension(directory, **kwargs)
 
     if enable:
-        path = jupyter_config_dir()
         if "prefix" in kwargs:
             path = join(kwargs["prefix"], "etc", "jupyter")
             if not exists(path):
                 print("Making directory", path)
                 os.makedirs(path)
+        else:
+            path = jupyter_config_dir()
 
         cm = ConfigManager(config_dir=path)
         print("Enabling nbpresent server component in", cm.config_dir)
@@ -63,15 +64,7 @@ def install(enable=False, **kwargs):
         print("New config...")
         pprint(cm.get("jupyter_notebook_config"))
 
-        _jupyter_config_dir = jupyter_config_dir()
-        # try:
-        #     subprocess.call(["conda", "info", "--root"])
-        #     print("conda detected")
-        #     _jupyter_config_dir = ENV_CONFIG_PATH[0]
-        # except OSError:
-        #     print("conda not detected")
-
-        cm = ConfigManager(config_dir=join(_jupyter_config_dir, "nbconfig"))
+        cm = ConfigManager(config_dir=join(path, "nbconfig"))
         print(
             "Enabling nbpresent nbextension at notebook launch in",
             cm.config_dir


### PR DESCRIPTION
Removing old stuff... and enabling the CM to write in path instead of hardcoding the `jupyter_config_dir`Removing old stuff... and enabling the CM to write in path instead of hardcoding the `jupyter_config_dir`.
Also using `nb_config_manager` as a conda dependency (this should not affect people trying this with pip, but enforce people suing conda to use the custom config manager until this is fixed upstream in the notebook 4.2).
I also added nbbrowserpdf as a dependency for nbpresent... I think the pdf exportation is important enough to ship it by default to the conda user.